### PR TITLE
Add plantuml activity diagram

### DIFF
--- a/work_report_activity.puml
+++ b/work_report_activity.puml
@@ -1,0 +1,37 @@
+@startuml
+' Activity diagram for work report processing
+!define AWSPUML https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/v14.0/LATEST/AWSPUML
+!includeurl AWSPUML
+
+|Staff|
+start
+:Fill work report with tasks, hours and supervisor remarks;
+if (Documents attached?) then (yes)
+  :Sign report;
+else (no)
+  :Await documents; 
+  stop
+endif
+:Submit to Supervisor;
+|Supervisor|
+if (Review tasks?) then (complete)
+  :Approve each task;
+  :Confirm report;
+else
+  :Request corrections;
+  |Staff|
+  :Update report;
+  :Resubmit to Supervisor;
+endif
+|Head of Section|
+if (Supervisor approved?) then (yes)
+  :Final approval;
+else
+  :Hold report;
+  stop
+endif
+|Finance|
+:Calculate total hours;
+:Process payment;
+stop
+@enduml


### PR DESCRIPTION
## Summary
- add `work_report_activity.puml` diagram describing monthly work report process

## Testing
- `plantuml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0910de3c8329b72b4654fc376d4a