### PR TITLE
Remove generated PNG diagrams

### DIFF
--- a/work_report_activity.puml
+++ b/work_report_activity.puml
@@ -1,0 +1,54 @@
+@startuml
+' Activity diagram for University of Nairobi monthly work report
+' Uses modern PlantUML partition syntax
+
+start
+
+partition "Staff" {
+    :Enter personal info (name, phone);
+    :Specify report period (start / end date);
+    :Fill task grid (S/no, Task, Activities, Date, Hrs, Supervisor, Remarks);
+    :Attach scanned documents (staff movement, employment offer);
+    if (All documents attached?) then (yes)
+        :Sign report;
+    else
+        :Await missing docs;
+        --> Staff;
+    endif
+    :Submit to Supervisor;
+}
+
+partition "Supervisor" {
+    if (Review tasks complete?) then (yes)
+        :Approve each task;
+        :Confirm report;
+    else
+        :Request corrections;
+        --> Staff;
+    endif
+    if (All docs verified?) then (yes)
+        :Sign as confirmed;
+    else
+        :Hold until docs complete;
+        --> Staff;
+    endif
+}
+
+partition "Head of Section" {
+    if (Supervisor signed?) then (yes)
+        :Final approval;
+    else
+        :Return for corrections;
+        --> Staff;
+    endif
+}
+
+partition "Finance" {
+    :Compute total hours from tasks;
+    :Calculate payment per contract;
+    :Mark report as paid;
+    :Generate summary reports;
+}
+
+stop
+@enduml

--- a/work_report_schema.puml
+++ b/work_report_schema.puml
@@ -1,0 +1,100 @@
+@startuml
+' Database schema for work report system
+left to right direction
+hide circle
+
+entity "users" {
+    *id : serial
+    --
+    full_name : varchar(255)
+    phone_number : varchar(20)
+    role : varchar(50)
+    created_at : timestamp
+}
+
+entity "work_reports" {
+    *id : serial
+    --
+    title : varchar(255)
+    staff_id : int
+    start_date : date
+    end_date : date
+    signed_staff_signature : text
+    supervisor_confirmed : boolean
+    supervisor_name : varchar(255)
+    supervisor_signature : text
+    supervisor_date : date
+    head_section_endorsed : boolean
+    head_section_signature : text
+    head_section_date : date
+    is_fully_processed : boolean
+    is_paid : boolean
+    created_at : timestamp
+}
+
+entity "report_tasks" {
+    *id : serial
+    --
+    report_id : int
+    serial_no : int
+    task_title : varchar(255)
+    activities : text
+    date_completed : date
+    hours_worked : numeric(5,2)
+    supervisor_id : int
+    supervisor_remarks : text
+}
+
+entity "scanned_documents" {
+    *id : serial
+    --
+    report_id : int
+    doc_type : varchar(100)
+    image_url : text
+    staff_signature : text
+    director_signature : text
+    contract_start_date : date
+}
+
+entity "approval_log" {
+    *id : serial
+    --
+    report_id : int
+    approved_by : int
+    role : varchar(50)
+    approved_at : timestamp
+    remarks : text
+}
+
+entity "earnings_summary" {
+    *id : serial
+    --
+    staff_id : int
+    month_start : date
+    month_end : date
+    total_hours : numeric(6,2)
+    hourly_rate : numeric(10,2)
+    total_earned : numeric(10,2)
+    is_paid : boolean
+}
+
+entity "feedback" {
+    *id : serial
+    --
+    report_id : int
+    given_by : int
+    role : varchar(50)
+    feedback_text : text
+    created_at : timestamp
+}
+
+users ||--o{ work_reports : "staff_id"
+work_reports ||--o{ report_tasks : "report_id"
+work_reports ||--o{ scanned_documents : "report_id"
+work_reports ||--o{ approval_log : "report_id"
+users ||--o{ approval_log : "approved_by"
+users ||--o{ report_tasks : "supervisor_id"
+users ||--o{ earnings_summary : "staff_id"
+work_reports ||--o{ feedback : "report_id"
+users ||--o{ feedback : "given_by"
+@enduml


### PR DESCRIPTION
## Summary
- keep only PlantUML sources and delete binary PNG outputs

## Testing
- `plantuml work_report_activity.puml` *(fails: command not found)*
- `plantuml work_report_schema.puml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0910de3c8329b72b4654fc376d4a